### PR TITLE
I think now its full addapted to work on windows with no downloads

### DIFF
--- a/BearHttpsClient.c
+++ b/BearHttpsClient.c
@@ -22,11 +22,13 @@ SOFTWARE.
  */ 
 #include "BearHttpsClient.h"
 
-#ifndef LuaSilverChain_fdefine
-#define LuaSilverChain_fdefine
+#ifndef BearHttpsClient_fdefine
+#define BearHttpsClient_fdefine
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -67,7 +69,9 @@ char * private_BearHttps_format_vaarg(const char *expresion, va_list args){
 }
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -105,7 +109,9 @@ private_BearHttpsKeyVal * private_BearHttpsHeaders_get_key_val_by_index(private_
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -137,7 +143,9 @@ void  private_BearHttpsKeyVal_free(private_BearHttpsKeyVal *self){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -153,7 +161,9 @@ BearHttpsNamespace newBearHttpsNamespace(){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -195,7 +205,9 @@ BearHttpsRequestNamespace newBearHttpsRequestNamespace(){
 }
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -225,7 +237,9 @@ BearHttpsResponseNamespace newBearHttpsResponseNamespace(){
 }
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -237,18 +251,18 @@ static int private_BearHttpsRequest_connect_ipv4(BearHttpsResponse *self, const 
         return -1; 
     }
 
-    struct sockaddr_in server_addr;
+    Universal_sockaddr_in server_addr;
     memset(&server_addr, 0, sizeof(server_addr));
-    server_addr.sin_family = AF_INET;
-    server_addr.sin_port = htons(port); 
+    server_addr.sin_family = UNI_AF_INET;
+    server_addr.sin_port = Universal_htons(port); 
 
-    if (inet_pton(AF_INET, ipv4_ip, &server_addr.sin_addr) <= 0) {
+    if (Universal_inet_pton(UNI_AF_INET, ipv4_ip, &server_addr.sin_addr) <= 0) {
         BearHttpsResponse_set_error(self,"ERROR: invalid address",BEARSSL_HTTPS_INVALID_IPV4);
         Universal_close(sockfd);
         return -1;
     }
 
-    if (connect(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+    if (Universal_connect(sockfd, (Universal_sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
         BearHttpsResponse_set_error(self,"ERROR: failed to connect",BEARSSL_HTTPS_FAILT_TO_CONNECT);
         Universal_close(sockfd); 
         return -1;
@@ -257,22 +271,22 @@ static int private_BearHttpsRequest_connect_ipv4(BearHttpsResponse *self, const 
     return sockfd;
 }
 static int private_BearHttpsRequest_connect_ipv4_no_error_raise( const char *ipv4_ip, int port) {
-    int sockfd = Universal_socket(AF_INET, SOCK_STREAM, 0);
+    int sockfd = Universal_socket(UNI_AF_INET, UNI_SOCK_STREAM, 0);
     if (sockfd < 0) {
-        return -1; 
+        return -1;
     }
 
-    struct sockaddr_in server_addr;
+    Universal_sockaddr_in server_addr;
     memset(&server_addr, 0, sizeof(server_addr));
-    server_addr.sin_family = AF_INET;
-    server_addr.sin_port = htons(port); 
+    server_addr.sin_family = UNI_AF_INET;
+    server_addr.sin_port = Universal_htons(port); 
 
-    if (inet_pton(AF_INET, ipv4_ip, &server_addr.sin_addr) <= 0) {
+    if (Universal_inet_pton(UNI_AF_INET, ipv4_ip, &server_addr.sin_addr) <= 0) {
         Universal_close(sockfd);
         return -1;
     }
 
-    if (connect(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+    if (Universal_connect(sockfd, (Universal_sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
         Universal_close(sockfd); 
         return -1;
     }
@@ -430,7 +444,9 @@ static int private_BearHttps_sock_write(void *ctx, const unsigned char *buf, siz
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -470,7 +486,9 @@ void private_BearsslHttps_set_str_considering_ownership(
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -654,7 +672,9 @@ cJSON * BearHttpsRequest_create_cJSONPayloadArray(BearHttpsRequest *self){
 #endif
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -838,7 +858,9 @@ BearHttpsResponse * BearHttpsRequest_fetch(BearHttpsRequest *self){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -961,7 +983,9 @@ void BearHttpsRequest_free(BearHttpsRequest *self){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -1052,7 +1076,9 @@ void private_BearHttpsRequisitionProps_free(private_BearHttpsRequisitionProps *s
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -1182,7 +1208,9 @@ void private_BearHttpsResponse_read_til_end_of_headers_or_reach_limit(
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -1377,7 +1405,9 @@ cJSON * BearHttpsResponse_read_body_json(BearHttpsResponse *self){
 #endif
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -1519,9 +1549,15 @@ char* BearHttpsResponse_get_header_value_by_sanitized_key(BearHttpsResponse*self
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
+
+#ifdef _WIN32
+typedef __m128i __m128i_u;
+#endif
 
 #if !defined(BEARSSL_HTTPS_MOCK_UNIVERSAL_SOCKET_DEFINE)
 /* MIT License
@@ -1552,13 +1588,13 @@ SOFTWARE.
 #define UniversalSocket_def
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
-extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags){
-    return recv(fd, buf, n,flags);
-}
+
 extern ssize_t Universal_send (int fd, const void *buf, size_t n, int flags){
     return send(fd,buf,n,flags);
 }
@@ -1675,7 +1711,9 @@ extern in_addr_t Universal_inet_addr(const char *ip) {
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -1695,7 +1733,9 @@ extern int Universal_connect(int sockfd, const Universal_sockaddr *addr, socklen
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -1709,7 +1749,9 @@ const char* Universal_gai_strerror(int e_code){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -1754,7 +1796,9 @@ Universal_hostent *Universal_gethostbyname(const char *hostname){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -1766,13 +1810,19 @@ extern const char* Universal_inet_ntoa(Universal_in_addr addr) {
   return inet_ntop(UNI_AF_INET, &addr, buffer, INET_ADDRSTRLEN);
 }
 
+extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags){
+    return recv(fd, buf, n,flags);
+}
+
 #endif
 
 
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -1795,7 +1845,9 @@ extern char *Universal_GetLastError(){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -1834,7 +1886,9 @@ void Universal_freeaddrinfo(Universal_addrinfo *addrinfo_ptr){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -1845,13 +1899,41 @@ extern const char* Universal_inet_ntoa(Universal_in_addr addr) {
   return inet_ntoa(addr);
 }
 
+ssize_t private_Universal_recv_all(int fd, void *buf, size_t n){
+  int max = 0;
+  int received;
+
+  while (max < n) {
+    received = recv(fd, buf + max, n - max, 0);
+  
+    if (received <= 0) { 
+      return received;
+    }
+
+    max += received;
+  }
+
+  return max;
+}
+
+extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags){
+
+  if(flags == UNI_MSG_WAITALL){
+    return private_Universal_recv_all(fd, buf, n);
+  }
+
+  return recv(fd, buf, n, flags);
+}
+
 #endif
 
 
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -1890,7 +1972,9 @@ extern char *Universal_GetLastError(){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -1914,9 +1998,6 @@ extern int Universal_close (int fd){
 
 //#if defined(_GET_ADDR_INFO_DEFAULT_)
 int Universal_getaddrinfo(const char *node, const char *service, const Universal_addrinfo *hints, Universal_addrinfo **res){
-    if (getaddrinfo) {
-        return getaddrinfo(node, service, hints, res);
-    }
 
 
     Universal_hostent *he;
@@ -1959,10 +2040,7 @@ int Universal_getaddrinfo(const char *node, const char *service, const Universal
 
 
 void Universal_freeaddrinfo(Universal_addrinfo *addrinfo_ptr){
-    if(getaddrinfo){
-        freeaddrinfo(addrinfo_ptr);
-        return;
-    }
+
     free(addrinfo_ptr->ai_addr);
     free(addrinfo_ptr->ai_canonname);
     free(addrinfo_ptr);
@@ -66301,8 +66379,11 @@ CJSON_PUBLIC(void) cJSON_free(void *object)
 
 #endif
 
+
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 

--- a/BearHttpsClient.h
+++ b/BearHttpsClient.h
@@ -20,8 +20,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */ 
-#ifndef LuaSilverChain_dep_declare
-#define LuaSilverChain_dep_declare
+#ifndef BearHttpsClient_dep_declare
+#define BearHttpsClient_dep_declare
 
 
 #include <stdlib.h>
@@ -115,7 +115,9 @@ SOFTWARE.
 #define UniversalSocket_mac
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -130,7 +132,6 @@ SOFTWARE.
 #define UNI_SOCK_DGRAM SOCK_DGRAM
 #define UNI_SOCK_RAW SOCK_RAW
 #define UNI_MSG_PEEK MSG_PEEK
-#define UNI_MSG_WAITALL MSG_WAITALL
 #define UNI_SO_RCVTIMEO SO_RCVTIMEO
 #define UNI_SO_SNDTIMEO SO_SNDTIMEO
 #define UNI_SO_KEEPALIVE SO_KEEPALIVE
@@ -160,7 +161,9 @@ SOFTWARE.
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -177,6 +180,7 @@ SOFTWARE.
 #define UNI_EINPROGRESS EINPROGRESS
 #define UNI_EADDRNOTAVAIL EADDRNOTAVAIL
 #define UNI_ENETUNREACH ENETUNREACH
+#define UNI_MSG_WAITALL MSG_WAITALL
 
 #define UNI_EAI_NONAME EAI_NONAME 
 #define UNI_EAI_AGAIN EAI_AGAIN
@@ -187,7 +191,9 @@ SOFTWARE.
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -198,6 +204,7 @@ SOFTWARE.
 #define UNI_SOCKET_ERROR SOCKET_ERROR
 #define UNI_EAGAIN WSAEWOULDBLOCK
 #define UNI_EWOULDBLOCK WSAEWOULDBLOCK
+#define UNI_MSG_WAITALL 0
 
 #define UNI_ECONNREFUSED WSAECONNREFUSED
 #define UNI_ETIMEDOUT WSAETIMEDOUT
@@ -225,7 +232,9 @@ SOFTWARE.
 #define UniversalSocket_types
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -250,7 +259,9 @@ typedef struct hostent Universal_hostent;
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -268,7 +279,9 @@ typedef ssize_t Universal_ssize_t;
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -294,7 +307,9 @@ typedef long Universal_ssize_t;
 #define UniversalSocket_dec
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -302,16 +317,17 @@ typedef long Universal_ssize_t;
 
 extern const char* Universal_inet_ntoa(Universal_in_addr addr);
 
-
+extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags);
 
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
-extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags);
 
 extern ssize_t Universal_send (int fd, const void *buf, size_t n, int flags);
 
@@ -331,7 +347,9 @@ extern in_addr_t Universal_inet_addr(const char *ip);
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -348,7 +366,9 @@ extern int Universal_connect(int sockfd, const Universal_sockaddr *addr, socklen
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -364,7 +384,9 @@ int Universal_getaddrinfo(const char *node, const char *service, const Universal
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -380,7 +402,9 @@ extern char *Universal_GetLastError();
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -402,7 +426,9 @@ void Universal_freeaddrinfo(Universal_addrinfo *addrinfo_ptr);
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -431,6 +457,22 @@ Universal_hostent *Universal_gethostbyname(const char *hostname);
 
 
 
+
+
+//silver_chain_scope_start
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
+
+//silver_chain_scope_end
+
+
+
+#if defined(_WIN32)
+
+ssize_t private_Universal_recv_all(int fd, void *buf, size_t n);
+
+#endif
 
 #endif
 
@@ -26906,11 +26948,13 @@ CJSON_PUBLIC(void) cJSON_free(void *object);
 
 #endif
 
-#ifndef LuaSilverChain_types
-#define LuaSilverChain_types
+#ifndef BearHttpsClient_types
+#define BearHttpsClient_types
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -26926,7 +26970,9 @@ typedef struct  private_BearHttpsKeyVal{
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -26955,7 +27001,9 @@ typedef struct private_BearHttpsBodyJsonRequest{
 #endif
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -26969,7 +27017,9 @@ typedef struct BearHttpsClientDnsProvider {
 }BearHttpsClientDnsProvider;
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -26986,11 +27036,13 @@ typedef struct private_BearHttpsRequisitionProps{
 
 #endif
 
-#ifndef LuaSilverChain_typesB
-#define LuaSilverChain_typesB
+#ifndef BearHttpsClient_typesB
+#define BearHttpsClient_typesB
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27002,11 +27054,13 @@ typedef struct  private_BearHttpsHeaders{
 
 #endif
 
-#ifndef LuaSilverChain_typesC
-#define LuaSilverChain_typesC
+#ifndef BearHttpsClient_typesC
+#define BearHttpsClient_typesC
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27051,11 +27105,13 @@ typedef struct BearHttpsRequest{
 
 #endif
 
-#ifndef LuaSilverChain_typesD
-#define LuaSilverChain_typesD
+#ifndef BearHttpsClient_typesD
+#define BearHttpsClient_typesD
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27092,11 +27148,13 @@ typedef struct BearHttpsResponse{
 
 #endif
 
-#ifndef LuaSilverChain_typesE
-#define LuaSilverChain_typesE
+#ifndef BearHttpsClient_typesE
+#define BearHttpsClient_typesE
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 typedef struct BearHttpsRequestNamespace{
@@ -27138,7 +27196,9 @@ void (*set_dns_providers)(BearHttpsRequest *self ,BearHttpsClientDnsProvider  *d
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 typedef struct BearHttpsResponseNamespace{
@@ -27182,11 +27242,13 @@ typedef struct BearHttpsResponseNamespace{
 
 #endif
 
-#ifndef LuaSilverChain_typesH
-#define LuaSilverChain_typesH
+#ifndef BearHttpsClient_typesH
+#define BearHttpsClient_typesH
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27200,11 +27262,13 @@ typedef struct BearHttpsNamespace{
 
 #endif
 
-#ifndef LuaSilverChain_consts
-#define LuaSilverChain_consts
+#ifndef BearHttpsClient_consts
+#define BearHttpsClient_consts
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27215,7 +27279,9 @@ typedef struct BearHttpsNamespace{
 #define PRIVATE_BEARSSL_BODY_JSON 3
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27231,7 +27297,9 @@ BearHttpsClientDnsProvider privateBearHttpsProviders[] = {
 int privateBearHttpsProvidersSize = sizeof(privateBearHttpsProviders)/sizeof(BearHttpsClientDnsProvider);
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27255,7 +27323,9 @@ int privateBearHttpsProvidersSize = sizeof(privateBearHttpsProviders)/sizeof(Bea
 #define BEARSSL_HTTPS_IMPOSSIBLE_TO_SEND_DATA 17
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 #define BEARSSL_HTTPS_REFERENCE  0
@@ -27266,7 +27336,9 @@ int privateBearHttpsProvidersSize = sizeof(privateBearHttpsProviders)/sizeof(Bea
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 #define BEARSSL_HEADER_CHUNK           200
@@ -27276,11 +27348,13 @@ int privateBearHttpsProvidersSize = sizeof(privateBearHttpsProviders)/sizeof(Bea
 #define BEARSSL_BODY_REALLOC_FACTOR      1.5
 #endif
 
-#ifndef LuaSilverChain_fdeclare
-#define LuaSilverChain_fdeclare
+#ifndef BearHttpsClient_fdeclare
+#define BearHttpsClient_fdeclare
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27289,7 +27363,9 @@ bool private_BearHttps_is_sanitize_key(const char *key,const char *sanitized,int
 char * private_BearHttps_format_vaarg(const char *expresion, va_list args);
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27304,7 +27380,9 @@ private_BearHttpsKeyVal * private_BearHttpsHeaders_get_key_val_by_index(private_
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27320,7 +27398,9 @@ void  private_BearHttpsKeyVal_free(private_BearHttpsKeyVal *self);
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27329,7 +27409,9 @@ BearHttpsNamespace newBearHttpsNamespace();
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27338,7 +27420,9 @@ BearHttpsRequestNamespace newBearHttpsRequestNamespace();
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27346,7 +27430,9 @@ BearHttpsResponseNamespace newBearHttpsResponseNamespace();
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27365,7 +27451,9 @@ static int private_BearHttps_sock_write(void *ctx, const unsigned char *buf, siz
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27375,7 +27463,9 @@ void private_BearsslHttps_set_str_considering_ownership(char **dest, char *value
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27412,7 +27502,9 @@ cJSON * BearHttpsRequest_create_cJSONPayloadArray(BearHttpsRequest *self);
 #endif
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27422,7 +27514,9 @@ BearHttpsResponse * BearHttpsRequest_fetch(BearHttpsRequest *self);
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27462,7 +27556,9 @@ void BearHttpsRequest_free(BearHttpsRequest *self);
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27474,7 +27570,9 @@ private_BearHttpsRequisitionProps * private_new_private_BearHttpsRequisitionProp
 void private_BearHttpsRequisitionProps_free(private_BearHttpsRequisitionProps *self);
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27536,7 +27634,9 @@ cJSON * BearHttpsResponse_read_body_json(BearHttpsResponse *self);
 #endif 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 long private_BearsslHttps_strlen(const char *str);

--- a/BearHttpsClientOne.c
+++ b/BearHttpsClientOne.c
@@ -23,8 +23,8 @@ SOFTWARE.
 
 #ifndef BEARHTTPS_CLIENT_ONE
 #define BEARHTTPS_CLIENT_ONE
-#ifndef LuaSilverChain_dep_declare
-#define LuaSilverChain_dep_declare
+#ifndef BearHttpsClient_dep_declare
+#define BearHttpsClient_dep_declare
 
 
 #include <stdlib.h>
@@ -118,7 +118,9 @@ SOFTWARE.
 #define UniversalSocket_mac
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -133,7 +135,6 @@ SOFTWARE.
 #define UNI_SOCK_DGRAM SOCK_DGRAM
 #define UNI_SOCK_RAW SOCK_RAW
 #define UNI_MSG_PEEK MSG_PEEK
-#define UNI_MSG_WAITALL MSG_WAITALL
 #define UNI_SO_RCVTIMEO SO_RCVTIMEO
 #define UNI_SO_SNDTIMEO SO_SNDTIMEO
 #define UNI_SO_KEEPALIVE SO_KEEPALIVE
@@ -163,7 +164,9 @@ SOFTWARE.
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -180,6 +183,7 @@ SOFTWARE.
 #define UNI_EINPROGRESS EINPROGRESS
 #define UNI_EADDRNOTAVAIL EADDRNOTAVAIL
 #define UNI_ENETUNREACH ENETUNREACH
+#define UNI_MSG_WAITALL MSG_WAITALL
 
 #define UNI_EAI_NONAME EAI_NONAME 
 #define UNI_EAI_AGAIN EAI_AGAIN
@@ -190,7 +194,9 @@ SOFTWARE.
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -201,6 +207,7 @@ SOFTWARE.
 #define UNI_SOCKET_ERROR SOCKET_ERROR
 #define UNI_EAGAIN WSAEWOULDBLOCK
 #define UNI_EWOULDBLOCK WSAEWOULDBLOCK
+#define UNI_MSG_WAITALL 0
 
 #define UNI_ECONNREFUSED WSAECONNREFUSED
 #define UNI_ETIMEDOUT WSAETIMEDOUT
@@ -228,7 +235,9 @@ SOFTWARE.
 #define UniversalSocket_types
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -253,7 +262,9 @@ typedef struct hostent Universal_hostent;
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -271,7 +282,9 @@ typedef ssize_t Universal_ssize_t;
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -297,7 +310,9 @@ typedef long Universal_ssize_t;
 #define UniversalSocket_dec
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -305,16 +320,17 @@ typedef long Universal_ssize_t;
 
 extern const char* Universal_inet_ntoa(Universal_in_addr addr);
 
-
+extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags);
 
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
-extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags);
 
 extern ssize_t Universal_send (int fd, const void *buf, size_t n, int flags);
 
@@ -334,7 +350,9 @@ extern in_addr_t Universal_inet_addr(const char *ip);
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -351,7 +369,9 @@ extern int Universal_connect(int sockfd, const Universal_sockaddr *addr, socklen
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -367,7 +387,9 @@ int Universal_getaddrinfo(const char *node, const char *service, const Universal
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -383,7 +405,9 @@ extern char *Universal_GetLastError();
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -405,7 +429,9 @@ void Universal_freeaddrinfo(Universal_addrinfo *addrinfo_ptr);
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -434,6 +460,22 @@ Universal_hostent *Universal_gethostbyname(const char *hostname);
 
 
 
+
+
+//silver_chain_scope_start
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
+
+//silver_chain_scope_end
+
+
+
+#if defined(_WIN32)
+
+ssize_t private_Universal_recv_all(int fd, void *buf, size_t n);
+
+#endif
 
 #endif
 
@@ -26909,11 +26951,13 @@ CJSON_PUBLIC(void) cJSON_free(void *object);
 
 #endif
 
-#ifndef LuaSilverChain_types
-#define LuaSilverChain_types
+#ifndef BearHttpsClient_types
+#define BearHttpsClient_types
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -26929,7 +26973,9 @@ typedef struct  private_BearHttpsKeyVal{
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -26958,7 +27004,9 @@ typedef struct private_BearHttpsBodyJsonRequest{
 #endif
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -26972,7 +27020,9 @@ typedef struct BearHttpsClientDnsProvider {
 }BearHttpsClientDnsProvider;
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -26989,11 +27039,13 @@ typedef struct private_BearHttpsRequisitionProps{
 
 #endif
 
-#ifndef LuaSilverChain_typesB
-#define LuaSilverChain_typesB
+#ifndef BearHttpsClient_typesB
+#define BearHttpsClient_typesB
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27005,11 +27057,13 @@ typedef struct  private_BearHttpsHeaders{
 
 #endif
 
-#ifndef LuaSilverChain_typesC
-#define LuaSilverChain_typesC
+#ifndef BearHttpsClient_typesC
+#define BearHttpsClient_typesC
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27054,11 +27108,13 @@ typedef struct BearHttpsRequest{
 
 #endif
 
-#ifndef LuaSilverChain_typesD
-#define LuaSilverChain_typesD
+#ifndef BearHttpsClient_typesD
+#define BearHttpsClient_typesD
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27095,11 +27151,13 @@ typedef struct BearHttpsResponse{
 
 #endif
 
-#ifndef LuaSilverChain_typesE
-#define LuaSilverChain_typesE
+#ifndef BearHttpsClient_typesE
+#define BearHttpsClient_typesE
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 typedef struct BearHttpsRequestNamespace{
@@ -27141,7 +27199,9 @@ void (*set_dns_providers)(BearHttpsRequest *self ,BearHttpsClientDnsProvider  *d
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 typedef struct BearHttpsResponseNamespace{
@@ -27185,11 +27245,13 @@ typedef struct BearHttpsResponseNamespace{
 
 #endif
 
-#ifndef LuaSilverChain_typesH
-#define LuaSilverChain_typesH
+#ifndef BearHttpsClient_typesH
+#define BearHttpsClient_typesH
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27203,11 +27265,13 @@ typedef struct BearHttpsNamespace{
 
 #endif
 
-#ifndef LuaSilverChain_consts
-#define LuaSilverChain_consts
+#ifndef BearHttpsClient_consts
+#define BearHttpsClient_consts
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27218,7 +27282,9 @@ typedef struct BearHttpsNamespace{
 #define PRIVATE_BEARSSL_BODY_JSON 3
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27234,7 +27300,9 @@ BearHttpsClientDnsProvider privateBearHttpsProviders[] = {
 int privateBearHttpsProvidersSize = sizeof(privateBearHttpsProviders)/sizeof(BearHttpsClientDnsProvider);
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27258,7 +27326,9 @@ int privateBearHttpsProvidersSize = sizeof(privateBearHttpsProviders)/sizeof(Bea
 #define BEARSSL_HTTPS_IMPOSSIBLE_TO_SEND_DATA 17
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 #define BEARSSL_HTTPS_REFERENCE  0
@@ -27269,7 +27339,9 @@ int privateBearHttpsProvidersSize = sizeof(privateBearHttpsProviders)/sizeof(Bea
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 #define BEARSSL_HEADER_CHUNK           200
@@ -27279,11 +27351,13 @@ int privateBearHttpsProvidersSize = sizeof(privateBearHttpsProviders)/sizeof(Bea
 #define BEARSSL_BODY_REALLOC_FACTOR      1.5
 #endif
 
-#ifndef LuaSilverChain_fdeclare
-#define LuaSilverChain_fdeclare
+#ifndef BearHttpsClient_fdeclare
+#define BearHttpsClient_fdeclare
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27292,7 +27366,9 @@ bool private_BearHttps_is_sanitize_key(const char *key,const char *sanitized,int
 char * private_BearHttps_format_vaarg(const char *expresion, va_list args);
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27307,7 +27383,9 @@ private_BearHttpsKeyVal * private_BearHttpsHeaders_get_key_val_by_index(private_
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27323,7 +27401,9 @@ void  private_BearHttpsKeyVal_free(private_BearHttpsKeyVal *self);
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27332,7 +27412,9 @@ BearHttpsNamespace newBearHttpsNamespace();
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27341,7 +27423,9 @@ BearHttpsRequestNamespace newBearHttpsRequestNamespace();
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27349,7 +27433,9 @@ BearHttpsResponseNamespace newBearHttpsResponseNamespace();
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27368,7 +27454,9 @@ static int private_BearHttps_sock_write(void *ctx, const unsigned char *buf, siz
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27378,7 +27466,9 @@ void private_BearsslHttps_set_str_considering_ownership(char **dest, char *value
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27415,7 +27505,9 @@ cJSON * BearHttpsRequest_create_cJSONPayloadArray(BearHttpsRequest *self);
 #endif
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27425,7 +27517,9 @@ BearHttpsResponse * BearHttpsRequest_fetch(BearHttpsRequest *self);
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27465,7 +27559,9 @@ void BearHttpsRequest_free(BearHttpsRequest *self);
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27477,7 +27573,9 @@ private_BearHttpsRequisitionProps * private_new_private_BearHttpsRequisitionProp
 void private_BearHttpsRequisitionProps_free(private_BearHttpsRequisitionProps *self);
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27539,7 +27637,9 @@ cJSON * BearHttpsResponse_read_body_json(BearHttpsResponse *self);
 #endif 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 long private_BearsslHttps_strlen(const char *str);
@@ -27559,11 +27659,13 @@ int private_BearsslHttps_indexof_from_point(const char *str,char c,int start);
 char  private_BearsslHttps_parse_char_to_lower(char c);
 #endif
 
-#ifndef LuaSilverChain_fdefine
-#define LuaSilverChain_fdefine
+#ifndef BearHttpsClient_fdefine
+#define BearHttpsClient_fdefine
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27604,7 +27706,9 @@ char * private_BearHttps_format_vaarg(const char *expresion, va_list args){
 }
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27642,7 +27746,9 @@ private_BearHttpsKeyVal * private_BearHttpsHeaders_get_key_val_by_index(private_
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27674,7 +27780,9 @@ void  private_BearHttpsKeyVal_free(private_BearHttpsKeyVal *self){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27690,7 +27798,9 @@ BearHttpsNamespace newBearHttpsNamespace(){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27732,7 +27842,9 @@ BearHttpsRequestNamespace newBearHttpsRequestNamespace(){
 }
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27762,7 +27874,9 @@ BearHttpsResponseNamespace newBearHttpsResponseNamespace(){
 }
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27774,18 +27888,18 @@ static int private_BearHttpsRequest_connect_ipv4(BearHttpsResponse *self, const 
         return -1; 
     }
 
-    struct sockaddr_in server_addr;
+    Universal_sockaddr_in server_addr;
     memset(&server_addr, 0, sizeof(server_addr));
-    server_addr.sin_family = AF_INET;
-    server_addr.sin_port = htons(port); 
+    server_addr.sin_family = UNI_AF_INET;
+    server_addr.sin_port = Universal_htons(port); 
 
-    if (inet_pton(AF_INET, ipv4_ip, &server_addr.sin_addr) <= 0) {
+    if (Universal_inet_pton(UNI_AF_INET, ipv4_ip, &server_addr.sin_addr) <= 0) {
         BearHttpsResponse_set_error(self,"ERROR: invalid address",BEARSSL_HTTPS_INVALID_IPV4);
         Universal_close(sockfd);
         return -1;
     }
 
-    if (connect(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+    if (Universal_connect(sockfd, (Universal_sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
         BearHttpsResponse_set_error(self,"ERROR: failed to connect",BEARSSL_HTTPS_FAILT_TO_CONNECT);
         Universal_close(sockfd); 
         return -1;
@@ -27794,22 +27908,22 @@ static int private_BearHttpsRequest_connect_ipv4(BearHttpsResponse *self, const 
     return sockfd;
 }
 static int private_BearHttpsRequest_connect_ipv4_no_error_raise( const char *ipv4_ip, int port) {
-    int sockfd = Universal_socket(AF_INET, SOCK_STREAM, 0);
+    int sockfd = Universal_socket(UNI_AF_INET, UNI_SOCK_STREAM, 0);
     if (sockfd < 0) {
-        return -1; 
+        return -1;
     }
 
-    struct sockaddr_in server_addr;
+    Universal_sockaddr_in server_addr;
     memset(&server_addr, 0, sizeof(server_addr));
-    server_addr.sin_family = AF_INET;
-    server_addr.sin_port = htons(port); 
+    server_addr.sin_family = UNI_AF_INET;
+    server_addr.sin_port = Universal_htons(port); 
 
-    if (inet_pton(AF_INET, ipv4_ip, &server_addr.sin_addr) <= 0) {
+    if (Universal_inet_pton(UNI_AF_INET, ipv4_ip, &server_addr.sin_addr) <= 0) {
         Universal_close(sockfd);
         return -1;
     }
 
-    if (connect(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+    if (Universal_connect(sockfd, (Universal_sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
         Universal_close(sockfd); 
         return -1;
     }
@@ -27967,7 +28081,9 @@ static int private_BearHttps_sock_write(void *ctx, const unsigned char *buf, siz
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -28007,7 +28123,9 @@ void private_BearsslHttps_set_str_considering_ownership(
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -28191,7 +28309,9 @@ cJSON * BearHttpsRequest_create_cJSONPayloadArray(BearHttpsRequest *self){
 #endif
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -28375,7 +28495,9 @@ BearHttpsResponse * BearHttpsRequest_fetch(BearHttpsRequest *self){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -28498,7 +28620,9 @@ void BearHttpsRequest_free(BearHttpsRequest *self){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -28589,7 +28713,9 @@ void private_BearHttpsRequisitionProps_free(private_BearHttpsRequisitionProps *s
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -28719,7 +28845,9 @@ void private_BearHttpsResponse_read_til_end_of_headers_or_reach_limit(
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -28914,7 +29042,9 @@ cJSON * BearHttpsResponse_read_body_json(BearHttpsResponse *self){
 #endif
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29056,9 +29186,15 @@ char* BearHttpsResponse_get_header_value_by_sanitized_key(BearHttpsResponse*self
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
+
+#ifdef _WIN32
+typedef __m128i __m128i_u;
+#endif
 
 #if !defined(BEARSSL_HTTPS_MOCK_UNIVERSAL_SOCKET_DEFINE)
 /* MIT License
@@ -29089,13 +29225,13 @@ SOFTWARE.
 #define UniversalSocket_def
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
-extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags){
-    return recv(fd, buf, n,flags);
-}
+
 extern ssize_t Universal_send (int fd, const void *buf, size_t n, int flags){
     return send(fd,buf,n,flags);
 }
@@ -29212,7 +29348,9 @@ extern in_addr_t Universal_inet_addr(const char *ip) {
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29232,7 +29370,9 @@ extern int Universal_connect(int sockfd, const Universal_sockaddr *addr, socklen
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29246,7 +29386,9 @@ const char* Universal_gai_strerror(int e_code){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29291,7 +29433,9 @@ Universal_hostent *Universal_gethostbyname(const char *hostname){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29303,13 +29447,19 @@ extern const char* Universal_inet_ntoa(Universal_in_addr addr) {
   return inet_ntop(UNI_AF_INET, &addr, buffer, INET_ADDRSTRLEN);
 }
 
+extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags){
+    return recv(fd, buf, n,flags);
+}
+
 #endif
 
 
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29332,7 +29482,9 @@ extern char *Universal_GetLastError(){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29371,7 +29523,9 @@ void Universal_freeaddrinfo(Universal_addrinfo *addrinfo_ptr){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29382,13 +29536,41 @@ extern const char* Universal_inet_ntoa(Universal_in_addr addr) {
   return inet_ntoa(addr);
 }
 
+ssize_t private_Universal_recv_all(int fd, void *buf, size_t n){
+  int max = 0;
+  int received;
+
+  while (max < n) {
+    received = recv(fd, buf + max, n - max, 0);
+  
+    if (received <= 0) { 
+      return received;
+    }
+
+    max += received;
+  }
+
+  return max;
+}
+
+extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags){
+
+  if(flags == UNI_MSG_WAITALL){
+    return private_Universal_recv_all(fd, buf, n);
+  }
+
+  return recv(fd, buf, n, flags);
+}
+
 #endif
 
 
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29427,7 +29609,9 @@ extern char *Universal_GetLastError(){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29451,9 +29635,6 @@ extern int Universal_close (int fd){
 
 //#if defined(_GET_ADDR_INFO_DEFAULT_)
 int Universal_getaddrinfo(const char *node, const char *service, const Universal_addrinfo *hints, Universal_addrinfo **res){
-    if (getaddrinfo) {
-        return getaddrinfo(node, service, hints, res);
-    }
 
 
     Universal_hostent *he;
@@ -29496,10 +29677,7 @@ int Universal_getaddrinfo(const char *node, const char *service, const Universal
 
 
 void Universal_freeaddrinfo(Universal_addrinfo *addrinfo_ptr){
-    if(getaddrinfo){
-        freeaddrinfo(addrinfo_ptr);
-        return;
-    }
+
     free(addrinfo_ptr->ai_addr);
     free(addrinfo_ptr->ai_canonname);
     free(addrinfo_ptr);
@@ -93838,8 +94016,11 @@ CJSON_PUBLIC(void) cJSON_free(void *object)
 
 #endif
 
+
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 

--- a/compiledarwin.bat
+++ b/compiledarwin.bat
@@ -1,1 +1,1 @@
-gcc dependencies/darwin.c -o darwin.out
+gcc dependencies/darwin.c -o darwin.exe

--- a/compiledarwin.bat
+++ b/compiledarwin.bat
@@ -1,0 +1,1 @@
+gcc dependencies/darwin.c -o darwin.out

--- a/darwin_build.bat
+++ b/darwin_build.bat
@@ -1,0 +1,1 @@
+./darwin.out run_blueprint

--- a/darwin_build.bat
+++ b/darwin_build.bat
@@ -1,1 +1,1 @@
-./darwin.out run_blueprint
+darwin.exe run_blueprint

--- a/darwinconf.lua
+++ b/darwinconf.lua
@@ -2,7 +2,8 @@
 darwin.silverchain.generate({
     src = "src",
     tags = { "dep_declare", "macros", "types","consts", "fdeclare", "fdefine" },
-    implement_main = false
+    implement_main = false,
+    project_short_cut = "BearHttpsClient",
 })
 
 

--- a/dependencies/UniversalSocket.c
+++ b/dependencies/UniversalSocket.c
@@ -26,13 +26,13 @@ SOFTWARE.
 #define UniversalSocket_def
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
-extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags){
-    return recv(fd, buf, n,flags);
-}
+
 extern ssize_t Universal_send (int fd, const void *buf, size_t n, int flags){
     return send(fd,buf,n,flags);
 }
@@ -149,7 +149,9 @@ extern in_addr_t Universal_inet_addr(const char *ip) {
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -169,7 +171,9 @@ extern int Universal_connect(int sockfd, const Universal_sockaddr *addr, socklen
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -183,7 +187,9 @@ const char* Universal_gai_strerror(int e_code){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -228,7 +234,9 @@ Universal_hostent *Universal_gethostbyname(const char *hostname){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -240,13 +248,19 @@ extern const char* Universal_inet_ntoa(Universal_in_addr addr) {
   return inet_ntop(UNI_AF_INET, &addr, buffer, INET_ADDRSTRLEN);
 }
 
+extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags){
+    return recv(fd, buf, n,flags);
+}
+
 #endif
 
 
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -269,7 +283,9 @@ extern char *Universal_GetLastError(){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -308,7 +324,9 @@ void Universal_freeaddrinfo(Universal_addrinfo *addrinfo_ptr){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -319,13 +337,41 @@ extern const char* Universal_inet_ntoa(Universal_in_addr addr) {
   return inet_ntoa(addr);
 }
 
+ssize_t private_Universal_recv_all(int fd, void *buf, size_t n){
+  int max = 0;
+  int received;
+
+  while (max < n) {
+    received = recv(fd, buf + max, n - max, 0);
+  
+    if (received <= 0) { 
+      return received;
+    }
+
+    max += received;
+  }
+
+  return max;
+}
+
+extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags){
+
+  if(flags == UNI_MSG_WAITALL){
+    return private_Universal_recv_all(fd, buf, n);
+  }
+
+  return recv(fd, buf, n, flags);
+}
+
 #endif
 
 
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -364,7 +410,9 @@ extern char *Universal_GetLastError(){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -388,9 +436,6 @@ extern int Universal_close (int fd){
 
 //#if defined(_GET_ADDR_INFO_DEFAULT_)
 int Universal_getaddrinfo(const char *node, const char *service, const Universal_addrinfo *hints, Universal_addrinfo **res){
-    if (getaddrinfo) {
-        return getaddrinfo(node, service, hints, res);
-    }
 
 
     Universal_hostent *he;
@@ -433,10 +478,7 @@ int Universal_getaddrinfo(const char *node, const char *service, const Universal
 
 
 void Universal_freeaddrinfo(Universal_addrinfo *addrinfo_ptr){
-    if(getaddrinfo){
-        freeaddrinfo(addrinfo_ptr);
-        return;
-    }
+
     free(addrinfo_ptr->ai_addr);
     free(addrinfo_ptr->ai_canonname);
     free(addrinfo_ptr);

--- a/dependencies/UniversalSocket.h
+++ b/dependencies/UniversalSocket.h
@@ -62,7 +62,9 @@ SOFTWARE.
 #define UniversalSocket_mac
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -77,7 +79,6 @@ SOFTWARE.
 #define UNI_SOCK_DGRAM SOCK_DGRAM
 #define UNI_SOCK_RAW SOCK_RAW
 #define UNI_MSG_PEEK MSG_PEEK
-#define UNI_MSG_WAITALL MSG_WAITALL
 #define UNI_SO_RCVTIMEO SO_RCVTIMEO
 #define UNI_SO_SNDTIMEO SO_SNDTIMEO
 #define UNI_SO_KEEPALIVE SO_KEEPALIVE
@@ -107,7 +108,9 @@ SOFTWARE.
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -124,6 +127,7 @@ SOFTWARE.
 #define UNI_EINPROGRESS EINPROGRESS
 #define UNI_EADDRNOTAVAIL EADDRNOTAVAIL
 #define UNI_ENETUNREACH ENETUNREACH
+#define UNI_MSG_WAITALL MSG_WAITALL
 
 #define UNI_EAI_NONAME EAI_NONAME 
 #define UNI_EAI_AGAIN EAI_AGAIN
@@ -134,7 +138,9 @@ SOFTWARE.
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -145,6 +151,7 @@ SOFTWARE.
 #define UNI_SOCKET_ERROR SOCKET_ERROR
 #define UNI_EAGAIN WSAEWOULDBLOCK
 #define UNI_EWOULDBLOCK WSAEWOULDBLOCK
+#define UNI_MSG_WAITALL 0
 
 #define UNI_ECONNREFUSED WSAECONNREFUSED
 #define UNI_ETIMEDOUT WSAETIMEDOUT
@@ -172,7 +179,9 @@ SOFTWARE.
 #define UniversalSocket_types
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -197,7 +206,9 @@ typedef struct hostent Universal_hostent;
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -215,7 +226,9 @@ typedef ssize_t Universal_ssize_t;
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -241,7 +254,9 @@ typedef long Universal_ssize_t;
 #define UniversalSocket_dec
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -249,16 +264,17 @@ typedef long Universal_ssize_t;
 
 extern const char* Universal_inet_ntoa(Universal_in_addr addr);
 
-
+extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags);
 
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
-extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags);
 
 extern ssize_t Universal_send (int fd, const void *buf, size_t n, int flags);
 
@@ -278,7 +294,9 @@ extern in_addr_t Universal_inet_addr(const char *ip);
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -295,7 +313,9 @@ extern int Universal_connect(int sockfd, const Universal_sockaddr *addr, socklen
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -311,7 +331,9 @@ int Universal_getaddrinfo(const char *node, const char *service, const Universal
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -327,7 +349,9 @@ extern char *Universal_GetLastError();
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -349,7 +373,9 @@ void Universal_freeaddrinfo(Universal_addrinfo *addrinfo_ptr);
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -378,5 +404,21 @@ Universal_hostent *Universal_gethostbyname(const char *hostname);
 
 
 
+
+
+//silver_chain_scope_start
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
+
+//silver_chain_scope_end
+
+
+
+#if defined(_WIN32)
+
+ssize_t private_Universal_recv_all(int fd, void *buf, size_t n);
+
+#endif
 
 #endif

--- a/examples/BearHttpsClientOne.c
+++ b/examples/BearHttpsClientOne.c
@@ -23,8 +23,8 @@ SOFTWARE.
 
 #ifndef BEARHTTPS_CLIENT_ONE
 #define BEARHTTPS_CLIENT_ONE
-#ifndef LuaSilverChain_dep_declare
-#define LuaSilverChain_dep_declare
+#ifndef BearHttpsClient_dep_declare
+#define BearHttpsClient_dep_declare
 
 
 #include <stdlib.h>
@@ -118,7 +118,9 @@ SOFTWARE.
 #define UniversalSocket_mac
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -133,7 +135,6 @@ SOFTWARE.
 #define UNI_SOCK_DGRAM SOCK_DGRAM
 #define UNI_SOCK_RAW SOCK_RAW
 #define UNI_MSG_PEEK MSG_PEEK
-#define UNI_MSG_WAITALL MSG_WAITALL
 #define UNI_SO_RCVTIMEO SO_RCVTIMEO
 #define UNI_SO_SNDTIMEO SO_SNDTIMEO
 #define UNI_SO_KEEPALIVE SO_KEEPALIVE
@@ -163,7 +164,9 @@ SOFTWARE.
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -180,6 +183,7 @@ SOFTWARE.
 #define UNI_EINPROGRESS EINPROGRESS
 #define UNI_EADDRNOTAVAIL EADDRNOTAVAIL
 #define UNI_ENETUNREACH ENETUNREACH
+#define UNI_MSG_WAITALL MSG_WAITALL
 
 #define UNI_EAI_NONAME EAI_NONAME 
 #define UNI_EAI_AGAIN EAI_AGAIN
@@ -190,7 +194,9 @@ SOFTWARE.
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -201,6 +207,7 @@ SOFTWARE.
 #define UNI_SOCKET_ERROR SOCKET_ERROR
 #define UNI_EAGAIN WSAEWOULDBLOCK
 #define UNI_EWOULDBLOCK WSAEWOULDBLOCK
+#define UNI_MSG_WAITALL 0
 
 #define UNI_ECONNREFUSED WSAECONNREFUSED
 #define UNI_ETIMEDOUT WSAETIMEDOUT
@@ -228,7 +235,9 @@ SOFTWARE.
 #define UniversalSocket_types
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -253,7 +262,9 @@ typedef struct hostent Universal_hostent;
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -271,7 +282,9 @@ typedef ssize_t Universal_ssize_t;
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -297,7 +310,9 @@ typedef long Universal_ssize_t;
 #define UniversalSocket_dec
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -305,16 +320,17 @@ typedef long Universal_ssize_t;
 
 extern const char* Universal_inet_ntoa(Universal_in_addr addr);
 
-
+extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags);
 
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
-extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags);
 
 extern ssize_t Universal_send (int fd, const void *buf, size_t n, int flags);
 
@@ -334,7 +350,9 @@ extern in_addr_t Universal_inet_addr(const char *ip);
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -351,7 +369,9 @@ extern int Universal_connect(int sockfd, const Universal_sockaddr *addr, socklen
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -367,7 +387,9 @@ int Universal_getaddrinfo(const char *node, const char *service, const Universal
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -383,7 +405,9 @@ extern char *Universal_GetLastError();
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -405,7 +429,9 @@ void Universal_freeaddrinfo(Universal_addrinfo *addrinfo_ptr);
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -434,6 +460,22 @@ Universal_hostent *Universal_gethostbyname(const char *hostname);
 
 
 
+
+
+//silver_chain_scope_start
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
+
+//silver_chain_scope_end
+
+
+
+#if defined(_WIN32)
+
+ssize_t private_Universal_recv_all(int fd, void *buf, size_t n);
+
+#endif
 
 #endif
 
@@ -26909,11 +26951,13 @@ CJSON_PUBLIC(void) cJSON_free(void *object);
 
 #endif
 
-#ifndef LuaSilverChain_types
-#define LuaSilverChain_types
+#ifndef BearHttpsClient_types
+#define BearHttpsClient_types
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -26929,7 +26973,9 @@ typedef struct  private_BearHttpsKeyVal{
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -26958,7 +27004,9 @@ typedef struct private_BearHttpsBodyJsonRequest{
 #endif
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -26972,7 +27020,9 @@ typedef struct BearHttpsClientDnsProvider {
 }BearHttpsClientDnsProvider;
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -26989,11 +27039,13 @@ typedef struct private_BearHttpsRequisitionProps{
 
 #endif
 
-#ifndef LuaSilverChain_typesB
-#define LuaSilverChain_typesB
+#ifndef BearHttpsClient_typesB
+#define BearHttpsClient_typesB
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27005,11 +27057,13 @@ typedef struct  private_BearHttpsHeaders{
 
 #endif
 
-#ifndef LuaSilverChain_typesC
-#define LuaSilverChain_typesC
+#ifndef BearHttpsClient_typesC
+#define BearHttpsClient_typesC
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27054,11 +27108,13 @@ typedef struct BearHttpsRequest{
 
 #endif
 
-#ifndef LuaSilverChain_typesD
-#define LuaSilverChain_typesD
+#ifndef BearHttpsClient_typesD
+#define BearHttpsClient_typesD
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27095,11 +27151,13 @@ typedef struct BearHttpsResponse{
 
 #endif
 
-#ifndef LuaSilverChain_typesE
-#define LuaSilverChain_typesE
+#ifndef BearHttpsClient_typesE
+#define BearHttpsClient_typesE
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 typedef struct BearHttpsRequestNamespace{
@@ -27141,7 +27199,9 @@ void (*set_dns_providers)(BearHttpsRequest *self ,BearHttpsClientDnsProvider  *d
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 typedef struct BearHttpsResponseNamespace{
@@ -27185,11 +27245,13 @@ typedef struct BearHttpsResponseNamespace{
 
 #endif
 
-#ifndef LuaSilverChain_typesH
-#define LuaSilverChain_typesH
+#ifndef BearHttpsClient_typesH
+#define BearHttpsClient_typesH
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27203,11 +27265,13 @@ typedef struct BearHttpsNamespace{
 
 #endif
 
-#ifndef LuaSilverChain_consts
-#define LuaSilverChain_consts
+#ifndef BearHttpsClient_consts
+#define BearHttpsClient_consts
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27218,7 +27282,9 @@ typedef struct BearHttpsNamespace{
 #define PRIVATE_BEARSSL_BODY_JSON 3
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27234,7 +27300,9 @@ BearHttpsClientDnsProvider privateBearHttpsProviders[] = {
 int privateBearHttpsProvidersSize = sizeof(privateBearHttpsProviders)/sizeof(BearHttpsClientDnsProvider);
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27258,7 +27326,9 @@ int privateBearHttpsProvidersSize = sizeof(privateBearHttpsProviders)/sizeof(Bea
 #define BEARSSL_HTTPS_IMPOSSIBLE_TO_SEND_DATA 17
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 #define BEARSSL_HTTPS_REFERENCE  0
@@ -27269,7 +27339,9 @@ int privateBearHttpsProvidersSize = sizeof(privateBearHttpsProviders)/sizeof(Bea
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 #define BEARSSL_HEADER_CHUNK           200
@@ -27279,11 +27351,13 @@ int privateBearHttpsProvidersSize = sizeof(privateBearHttpsProviders)/sizeof(Bea
 #define BEARSSL_BODY_REALLOC_FACTOR      1.5
 #endif
 
-#ifndef LuaSilverChain_fdeclare
-#define LuaSilverChain_fdeclare
+#ifndef BearHttpsClient_fdeclare
+#define BearHttpsClient_fdeclare
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27292,7 +27366,9 @@ bool private_BearHttps_is_sanitize_key(const char *key,const char *sanitized,int
 char * private_BearHttps_format_vaarg(const char *expresion, va_list args);
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27307,7 +27383,9 @@ private_BearHttpsKeyVal * private_BearHttpsHeaders_get_key_val_by_index(private_
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27323,7 +27401,9 @@ void  private_BearHttpsKeyVal_free(private_BearHttpsKeyVal *self);
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27332,7 +27412,9 @@ BearHttpsNamespace newBearHttpsNamespace();
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27341,7 +27423,9 @@ BearHttpsRequestNamespace newBearHttpsRequestNamespace();
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27349,7 +27433,9 @@ BearHttpsResponseNamespace newBearHttpsResponseNamespace();
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27368,7 +27454,9 @@ static int private_BearHttps_sock_write(void *ctx, const unsigned char *buf, siz
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27378,7 +27466,9 @@ void private_BearsslHttps_set_str_considering_ownership(char **dest, char *value
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27415,7 +27505,9 @@ cJSON * BearHttpsRequest_create_cJSONPayloadArray(BearHttpsRequest *self);
 #endif
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27425,7 +27517,9 @@ BearHttpsResponse * BearHttpsRequest_fetch(BearHttpsRequest *self);
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27465,7 +27559,9 @@ void BearHttpsRequest_free(BearHttpsRequest *self);
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27477,7 +27573,9 @@ private_BearHttpsRequisitionProps * private_new_private_BearHttpsRequisitionProp
 void private_BearHttpsRequisitionProps_free(private_BearHttpsRequisitionProps *self);
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27539,7 +27637,9 @@ cJSON * BearHttpsResponse_read_body_json(BearHttpsResponse *self);
 #endif 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 long private_BearsslHttps_strlen(const char *str);
@@ -27559,11 +27659,13 @@ int private_BearsslHttps_indexof_from_point(const char *str,char c,int start);
 char  private_BearsslHttps_parse_char_to_lower(char c);
 #endif
 
-#ifndef LuaSilverChain_fdefine
-#define LuaSilverChain_fdefine
+#ifndef BearHttpsClient_fdefine
+#define BearHttpsClient_fdefine
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27604,7 +27706,9 @@ char * private_BearHttps_format_vaarg(const char *expresion, va_list args){
 }
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27642,7 +27746,9 @@ private_BearHttpsKeyVal * private_BearHttpsHeaders_get_key_val_by_index(private_
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27674,7 +27780,9 @@ void  private_BearHttpsKeyVal_free(private_BearHttpsKeyVal *self){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27690,7 +27798,9 @@ BearHttpsNamespace newBearHttpsNamespace(){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27732,7 +27842,9 @@ BearHttpsRequestNamespace newBearHttpsRequestNamespace(){
 }
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27762,7 +27874,9 @@ BearHttpsResponseNamespace newBearHttpsResponseNamespace(){
 }
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -27774,18 +27888,18 @@ static int private_BearHttpsRequest_connect_ipv4(BearHttpsResponse *self, const 
         return -1; 
     }
 
-    struct sockaddr_in server_addr;
+    Universal_sockaddr_in server_addr;
     memset(&server_addr, 0, sizeof(server_addr));
-    server_addr.sin_family = AF_INET;
-    server_addr.sin_port = htons(port); 
+    server_addr.sin_family = UNI_AF_INET;
+    server_addr.sin_port = Universal_htons(port); 
 
-    if (inet_pton(AF_INET, ipv4_ip, &server_addr.sin_addr) <= 0) {
+    if (Universal_inet_pton(UNI_AF_INET, ipv4_ip, &server_addr.sin_addr) <= 0) {
         BearHttpsResponse_set_error(self,"ERROR: invalid address",BEARSSL_HTTPS_INVALID_IPV4);
         Universal_close(sockfd);
         return -1;
     }
 
-    if (connect(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+    if (Universal_connect(sockfd, (Universal_sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
         BearHttpsResponse_set_error(self,"ERROR: failed to connect",BEARSSL_HTTPS_FAILT_TO_CONNECT);
         Universal_close(sockfd); 
         return -1;
@@ -27794,22 +27908,22 @@ static int private_BearHttpsRequest_connect_ipv4(BearHttpsResponse *self, const 
     return sockfd;
 }
 static int private_BearHttpsRequest_connect_ipv4_no_error_raise( const char *ipv4_ip, int port) {
-    int sockfd = Universal_socket(AF_INET, SOCK_STREAM, 0);
+    int sockfd = Universal_socket(UNI_AF_INET, UNI_SOCK_STREAM, 0);
     if (sockfd < 0) {
-        return -1; 
+        return -1;
     }
 
-    struct sockaddr_in server_addr;
+    Universal_sockaddr_in server_addr;
     memset(&server_addr, 0, sizeof(server_addr));
-    server_addr.sin_family = AF_INET;
-    server_addr.sin_port = htons(port); 
+    server_addr.sin_family = UNI_AF_INET;
+    server_addr.sin_port = Universal_htons(port); 
 
-    if (inet_pton(AF_INET, ipv4_ip, &server_addr.sin_addr) <= 0) {
+    if (Universal_inet_pton(UNI_AF_INET, ipv4_ip, &server_addr.sin_addr) <= 0) {
         Universal_close(sockfd);
         return -1;
     }
 
-    if (connect(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+    if (Universal_connect(sockfd, (Universal_sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
         Universal_close(sockfd); 
         return -1;
     }
@@ -27967,7 +28081,9 @@ static int private_BearHttps_sock_write(void *ctx, const unsigned char *buf, siz
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -28007,7 +28123,9 @@ void private_BearsslHttps_set_str_considering_ownership(
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -28191,7 +28309,9 @@ cJSON * BearHttpsRequest_create_cJSONPayloadArray(BearHttpsRequest *self){
 #endif
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -28375,7 +28495,9 @@ BearHttpsResponse * BearHttpsRequest_fetch(BearHttpsRequest *self){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -28498,7 +28620,9 @@ void BearHttpsRequest_free(BearHttpsRequest *self){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -28589,7 +28713,9 @@ void private_BearHttpsRequisitionProps_free(private_BearHttpsRequisitionProps *s
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -28719,7 +28845,9 @@ void private_BearHttpsResponse_read_til_end_of_headers_or_reach_limit(
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -28914,7 +29042,9 @@ cJSON * BearHttpsResponse_read_body_json(BearHttpsResponse *self){
 #endif
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29056,9 +29186,15 @@ char* BearHttpsResponse_get_header_value_by_sanitized_key(BearHttpsResponse*self
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
+
+#ifdef _WIN32
+typedef __m128i __m128i_u;
+#endif
 
 #if !defined(BEARSSL_HTTPS_MOCK_UNIVERSAL_SOCKET_DEFINE)
 /* MIT License
@@ -29089,13 +29225,13 @@ SOFTWARE.
 #define UniversalSocket_def
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
-extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags){
-    return recv(fd, buf, n,flags);
-}
+
 extern ssize_t Universal_send (int fd, const void *buf, size_t n, int flags){
     return send(fd,buf,n,flags);
 }
@@ -29212,7 +29348,9 @@ extern in_addr_t Universal_inet_addr(const char *ip) {
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29232,7 +29370,9 @@ extern int Universal_connect(int sockfd, const Universal_sockaddr *addr, socklen
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29246,7 +29386,9 @@ const char* Universal_gai_strerror(int e_code){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29291,7 +29433,9 @@ Universal_hostent *Universal_gethostbyname(const char *hostname){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29303,13 +29447,19 @@ extern const char* Universal_inet_ntoa(Universal_in_addr addr) {
   return inet_ntop(UNI_AF_INET, &addr, buffer, INET_ADDRSTRLEN);
 }
 
+extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags){
+    return recv(fd, buf, n,flags);
+}
+
 #endif
 
 
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29332,7 +29482,9 @@ extern char *Universal_GetLastError(){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29371,7 +29523,9 @@ void Universal_freeaddrinfo(Universal_addrinfo *addrinfo_ptr){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29382,13 +29536,41 @@ extern const char* Universal_inet_ntoa(Universal_in_addr addr) {
   return inet_ntoa(addr);
 }
 
+ssize_t private_Universal_recv_all(int fd, void *buf, size_t n){
+  int max = 0;
+  int received;
+
+  while (max < n) {
+    received = recv(fd, buf + max, n - max, 0);
+  
+    if (received <= 0) { 
+      return received;
+    }
+
+    max += received;
+  }
+
+  return max;
+}
+
+extern ssize_t Universal_recv (int fd, void *buf, size_t n, int flags){
+
+  if(flags == UNI_MSG_WAITALL){
+    return private_Universal_recv_all(fd, buf, n);
+  }
+
+  return recv(fd, buf, n, flags);
+}
+
 #endif
 
 
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29427,7 +29609,9 @@ extern char *Universal_GetLastError(){
 
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 
@@ -29451,9 +29635,6 @@ extern int Universal_close (int fd){
 
 //#if defined(_GET_ADDR_INFO_DEFAULT_)
 int Universal_getaddrinfo(const char *node, const char *service, const Universal_addrinfo *hints, Universal_addrinfo **res){
-    if (getaddrinfo) {
-        return getaddrinfo(node, service, hints, res);
-    }
 
 
     Universal_hostent *he;
@@ -29496,10 +29677,7 @@ int Universal_getaddrinfo(const char *node, const char *service, const Universal
 
 
 void Universal_freeaddrinfo(Universal_addrinfo *addrinfo_ptr){
-    if(getaddrinfo){
-        freeaddrinfo(addrinfo_ptr);
-        return;
-    }
+
     free(addrinfo_ptr->ai_addr);
     free(addrinfo_ptr->ai_canonname);
     free(addrinfo_ptr);
@@ -93838,8 +94016,11 @@ CJSON_PUBLIC(void) cJSON_free(void *object)
 
 #endif
 
+
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 
 //silver_chain_scope_end
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -3,7 +3,7 @@ mkdir dependencies
 
 
 ### Required Tools 
-curl -L https://github.com/OUIsolutions/Darwin/releases/download/0.020/darwin.c -o dependencies/darwin.c
+curl -L https://github.com/OUIsolutions/Darwin/releases/download/0.1.22/darwin.c -o dependencies/darwin.c
 
 ### Project Dependencies
 
@@ -11,8 +11,8 @@ curl -L https://github.com/OUIsolutions/BearSslSingle-Unit/releases/download/0.0
 curl -L https://github.com/OUIsolutions/BearSslSingle-Unit/releases/download/0.0.3/BearSSLSingleUnit.c -o dependencies/BearSSLSingleUnit.c
 curl -L https://raw.githubusercontent.com/DaveGamble/cJSON/refs/tags/v1.7.18/cJSON.c -o dependencies/cJSON.c
 curl -L https://raw.githubusercontent.com/DaveGamble/cJSON/refs/tags/v1.7.18/cJSON.h -o dependencies/cJSON.h
-curl -L https://github.com/SamuelHenriqueDeMoraisVitrio/UniversalSocket/releases/download/v0.2.4/UniversalSocket.c -o dependencies/UniversalSocket.c
-curl -L https://github.com/SamuelHenriqueDeMoraisVitrio/UniversalSocket/releases/download/v0.2.4/UniversalSocket.h -o dependencies/UniversalSocket.h
+curl -L https://github.com/SamuelHenriqueDeMoraisVitrio/UniversalSocket/releases/download/v0.2.6/UniversalSocket.c -o dependencies/UniversalSocket.c
+curl -L https://github.com/SamuelHenriqueDeMoraisVitrio/UniversalSocket/releases/download/v0.2.6/UniversalSocket.h -o dependencies/UniversalSocket.h
 
 curl -L https://curl.se/ca/cacert.pem -o dependencies/cacert.pem
 

--- a/src/consts/consts.body_types.h
+++ b/src/consts/consts.body_types.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.typesH.h"
 //silver_chain_scope_end
 

--- a/src/consts/consts.dns.h
+++ b/src/consts/consts.dns.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.typesH.h"
 //silver_chain_scope_end
 

--- a/src/consts/consts.errors.h
+++ b/src/consts/consts.errors.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.typesH.h"
 //silver_chain_scope_end
 

--- a/src/consts/consts.ownership.h
+++ b/src/consts/consts.ownership.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.typesH.h"
 //silver_chain_scope_end
 #define BEARSSL_HTTPS_REFERENCE  0

--- a/src/consts/consts.sizes.h
+++ b/src/consts/consts.sizes.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.typesH.h"
 //silver_chain_scope_end
 #define BEARSSL_HEADER_CHUNK           200

--- a/src/extra/fdeclare.extra.h
+++ b/src/extra/fdeclare.extra.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.consts.h"
 //silver_chain_scope_end
 

--- a/src/extra/fdefine.extra.c
+++ b/src/extra/fdefine.extra.c
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.fdeclare.h"
 //silver_chain_scope_end
 

--- a/src/headers/fdeclare.headers.h
+++ b/src/headers/fdeclare.headers.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.consts.h"
 //silver_chain_scope_end
 

--- a/src/headers/fdefine.headers.c
+++ b/src/headers/fdefine.headers.c
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.fdeclare.h"
 //silver_chain_scope_end
 

--- a/src/headers/typesB.headers.h
+++ b/src/headers/typesB.headers.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.types.h"
 //silver_chain_scope_end
 

--- a/src/imports/imports.consts.h
+++ b/src/imports/imports.consts.h
@@ -1,6 +1,6 @@
 #include "imports.typesH.h"
-#ifndef LuaSilverChain_consts
-#define LuaSilverChain_consts
+#ifndef BearHttpsClient_consts
+#define BearHttpsClient_consts
 #include "../consts/consts.body_types.h"
 #include "../consts/consts.dns.h"
 #include "../consts/consts.errors.h"

--- a/src/imports/imports.dep_declare.h
+++ b/src/imports/imports.dep_declare.h
@@ -1,4 +1,4 @@
-#ifndef LuaSilverChain_dep_declare
-#define LuaSilverChain_dep_declare
+#ifndef BearHttpsClient_dep_declare
+#define BearHttpsClient_dep_declare
 #include "../src_dependencies/dep_declare.dependencies.h"
 #endif

--- a/src/imports/imports.fdeclare.h
+++ b/src/imports/imports.fdeclare.h
@@ -1,6 +1,6 @@
 #include "imports.consts.h"
-#ifndef LuaSilverChain_fdeclare
-#define LuaSilverChain_fdeclare
+#ifndef BearHttpsClient_fdeclare
+#define BearHttpsClient_fdeclare
 #include "../extra/fdeclare.extra.h"
 #include "../headers/fdeclare.headers.h"
 #include "../keyval/fdeclare.keyval.h"

--- a/src/imports/imports.fdefine.h
+++ b/src/imports/imports.fdefine.h
@@ -1,6 +1,6 @@
 #include "imports.fdeclare.h"
-#ifndef LuaSilverChain_fdefine
-#define LuaSilverChain_fdefine
+#ifndef BearHttpsClient_fdefine
+#define BearHttpsClient_fdefine
 #include "../extra/fdefine.extra.c"
 #include "../headers/fdefine.headers.c"
 #include "../keyval/fdefine.keyval.c"

--- a/src/imports/imports.types.h
+++ b/src/imports/imports.types.h
@@ -1,6 +1,6 @@
 #include "imports.dep_declare.h"
-#ifndef LuaSilverChain_types
-#define LuaSilverChain_types
+#ifndef BearHttpsClient_types
+#define BearHttpsClient_types
 #include "../keyval/types.keyval.h"
 #include "../request/types.body_types.h"
 #include "../request/types.dns_provider.h"

--- a/src/imports/imports.typesB.h
+++ b/src/imports/imports.typesB.h
@@ -1,5 +1,5 @@
 #include "imports.types.h"
-#ifndef LuaSilverChain_typesB
-#define LuaSilverChain_typesB
+#ifndef BearHttpsClient_typesB
+#define BearHttpsClient_typesB
 #include "../headers/typesB.headers.h"
 #endif

--- a/src/imports/imports.typesC.h
+++ b/src/imports/imports.typesC.h
@@ -1,5 +1,5 @@
 #include "imports.typesB.h"
-#ifndef LuaSilverChain_typesC
-#define LuaSilverChain_typesC
+#ifndef BearHttpsClient_typesC
+#define BearHttpsClient_typesC
 #include "../request/typesC.request.h"
 #endif

--- a/src/imports/imports.typesD.h
+++ b/src/imports/imports.typesD.h
@@ -1,5 +1,5 @@
 #include "imports.typesC.h"
-#ifndef LuaSilverChain_typesD
-#define LuaSilverChain_typesD
+#ifndef BearHttpsClient_typesD
+#define BearHttpsClient_typesD
 #include "../response/typesD.response.h"
 #endif

--- a/src/imports/imports.typesE.h
+++ b/src/imports/imports.typesE.h
@@ -1,6 +1,6 @@
 #include "imports.typesD.h"
-#ifndef LuaSilverChain_typesE
-#define LuaSilverChain_typesE
+#ifndef BearHttpsClient_typesE
+#define BearHttpsClient_typesE
 #include "../namespace/request/typesE.request.h"
 #include "../namespace/response/typesE.response.h"
 #endif

--- a/src/imports/imports.typesH.h
+++ b/src/imports/imports.typesH.h
@@ -1,5 +1,5 @@
 #include "imports.typesE.h"
-#ifndef LuaSilverChain_typesH
-#define LuaSilverChain_typesH
+#ifndef BearHttpsClient_typesH
+#define BearHttpsClient_typesH
 #include "../namespace/typesH.namespace.h"
 #endif

--- a/src/keyval/fdeclare.keyval.h
+++ b/src/keyval/fdeclare.keyval.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.consts.h"
 //silver_chain_scope_end
 

--- a/src/keyval/fdefine.keyval.c
+++ b/src/keyval/fdefine.keyval.c
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.fdeclare.h"
 //silver_chain_scope_end
 

--- a/src/keyval/types.keyval.h
+++ b/src/keyval/types.keyval.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.dep_declare.h"
 //silver_chain_scope_end
 

--- a/src/namespace/fdeclare.namespace.h
+++ b/src/namespace/fdeclare.namespace.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.consts.h"
 //silver_chain_scope_end
 

--- a/src/namespace/fdefine.namespace.c
+++ b/src/namespace/fdefine.namespace.c
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.fdeclare.h"
 //silver_chain_scope_end
 

--- a/src/namespace/request/fdeclare.request.h
+++ b/src/namespace/request/fdeclare.request.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../../imports/imports.consts.h"
 //silver_chain_scope_end
 

--- a/src/namespace/request/fdefine.request.c
+++ b/src/namespace/request/fdefine.request.c
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../../imports/imports.fdeclare.h"
 //silver_chain_scope_end
 

--- a/src/namespace/request/typesE.request.h
+++ b/src/namespace/request/typesE.request.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../../imports/imports.typesD.h"
 //silver_chain_scope_end
 typedef struct BearHttpsRequestNamespace{

--- a/src/namespace/response/fdeclare.response.h
+++ b/src/namespace/response/fdeclare.response.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../../imports/imports.consts.h"
 //silver_chain_scope_end
 

--- a/src/namespace/response/fdefine.response.c
+++ b/src/namespace/response/fdefine.response.c
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../../imports/imports.fdeclare.h"
 //silver_chain_scope_end
 

--- a/src/namespace/response/typesE.response.h
+++ b/src/namespace/response/typesE.response.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../../imports/imports.typesD.h"
 //silver_chain_scope_end
 typedef struct BearHttpsResponseNamespace{

--- a/src/namespace/typesH.namespace.h
+++ b/src/namespace/typesH.namespace.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.typesE.h"
 //silver_chain_scope_end
 

--- a/src/network/fdeclare.network.h
+++ b/src/network/fdeclare.network.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.consts.h"
 //silver_chain_scope_end
 

--- a/src/network/fdefine.network.c
+++ b/src/network/fdefine.network.c
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.fdeclare.h"
 //silver_chain_scope_end
 
@@ -12,18 +14,18 @@ static int private_BearHttpsRequest_connect_ipv4(BearHttpsResponse *self, const 
         return -1; 
     }
 
-    struct sockaddr_in server_addr;
+    Universal_sockaddr_in server_addr;
     memset(&server_addr, 0, sizeof(server_addr));
-    server_addr.sin_family = AF_INET;
-    server_addr.sin_port = htons(port); 
+    server_addr.sin_family = UNI_AF_INET;
+    server_addr.sin_port = Universal_htons(port); 
 
-    if (inet_pton(AF_INET, ipv4_ip, &server_addr.sin_addr) <= 0) {
+    if (Universal_inet_pton(UNI_AF_INET, ipv4_ip, &server_addr.sin_addr) <= 0) {
         BearHttpsResponse_set_error(self,"ERROR: invalid address",BEARSSL_HTTPS_INVALID_IPV4);
         Universal_close(sockfd);
         return -1;
     }
 
-    if (connect(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+    if (Universal_connect(sockfd, (Universal_sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
         BearHttpsResponse_set_error(self,"ERROR: failed to connect",BEARSSL_HTTPS_FAILT_TO_CONNECT);
         Universal_close(sockfd); 
         return -1;
@@ -32,22 +34,22 @@ static int private_BearHttpsRequest_connect_ipv4(BearHttpsResponse *self, const 
     return sockfd;
 }
 static int private_BearHttpsRequest_connect_ipv4_no_error_raise( const char *ipv4_ip, int port) {
-    int sockfd = Universal_socket(AF_INET, SOCK_STREAM, 0);
+    int sockfd = Universal_socket(UNI_AF_INET, UNI_SOCK_STREAM, 0);
     if (sockfd < 0) {
-        return -1; 
+        return -1;
     }
 
-    struct sockaddr_in server_addr;
+    Universal_sockaddr_in server_addr;
     memset(&server_addr, 0, sizeof(server_addr));
-    server_addr.sin_family = AF_INET;
-    server_addr.sin_port = htons(port); 
+    server_addr.sin_family = UNI_AF_INET;
+    server_addr.sin_port = Universal_htons(port); 
 
-    if (inet_pton(AF_INET, ipv4_ip, &server_addr.sin_addr) <= 0) {
+    if (Universal_inet_pton(UNI_AF_INET, ipv4_ip, &server_addr.sin_addr) <= 0) {
         Universal_close(sockfd);
         return -1;
     }
 
-    if (connect(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+    if (Universal_connect(sockfd, (Universal_sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
         Universal_close(sockfd); 
         return -1;
     }

--- a/src/ownership/fdeclare.ownership.h
+++ b/src/ownership/fdeclare.ownership.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.consts.h"
 //silver_chain_scope_end
 

--- a/src/ownership/fdefine.ownership.c
+++ b/src/ownership/fdefine.ownership.c
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.fdeclare.h"
 //silver_chain_scope_end
 

--- a/src/request/body_send/fdeclare.body_send .h
+++ b/src/request/body_send/fdeclare.body_send .h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../../imports/imports.consts.h"
 //silver_chain_scope_end
 

--- a/src/request/body_send/fdefine.body_send.c
+++ b/src/request/body_send/fdefine.body_send.c
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../../imports/imports.fdeclare.h"
 //silver_chain_scope_end
 

--- a/src/request/fetch/fdeclare.fetch.h
+++ b/src/request/fetch/fdeclare.fetch.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../../imports/imports.consts.h"
 //silver_chain_scope_end
 

--- a/src/request/fetch/fdefine.fetch.c
+++ b/src/request/fetch/fdefine.fetch.c
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../../imports/imports.fdeclare.h"
 //silver_chain_scope_end
 

--- a/src/request/request/fdeclare.request .h
+++ b/src/request/request/fdeclare.request .h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../../imports/imports.consts.h"
 //silver_chain_scope_end
 

--- a/src/request/request/fdefine.request.c
+++ b/src/request/request/fdefine.request.c
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../../imports/imports.fdeclare.h"
 //silver_chain_scope_end
 

--- a/src/request/types.body_types.h
+++ b/src/request/types.body_types.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.dep_declare.h"
 //silver_chain_scope_end
 

--- a/src/request/types.dns_provider.h
+++ b/src/request/types.dns_provider.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.dep_declare.h"
 //silver_chain_scope_end
 

--- a/src/request/typesC.request.h
+++ b/src/request/typesC.request.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.typesB.h"
 //silver_chain_scope_end
 

--- a/src/requisition_props/fdeclare.requisition_props.h
+++ b/src/requisition_props/fdeclare.requisition_props.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.consts.h"
 //silver_chain_scope_end
 

--- a/src/requisition_props/fdefine.requisition_props.c
+++ b/src/requisition_props/fdefine.requisition_props.c
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.fdeclare.h"
 //silver_chain_scope_end
 

--- a/src/requisition_props/types.requisition_props.h
+++ b/src/requisition_props/types.requisition_props.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.dep_declare.h"
 //silver_chain_scope_end
 

--- a/src/response/fdeclare.response.h
+++ b/src/response/fdeclare.response.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.consts.h"
 //silver_chain_scope_end
 

--- a/src/response/fdefine.http_parser.c
+++ b/src/response/fdefine.http_parser.c
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.fdeclare.h"
 //silver_chain_scope_end
 

--- a/src/response/fdefine.read_write.c
+++ b/src/response/fdefine.read_write.c
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.fdeclare.h"
 //silver_chain_scope_end
 

--- a/src/response/fdefine.response.c
+++ b/src/response/fdefine.response.c
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.fdeclare.h"
 //silver_chain_scope_end
 

--- a/src/response/typesD.response.h
+++ b/src/response/typesD.response.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.typesC.h"
 //silver_chain_scope_end
 

--- a/src/src_dependencies/fdefine.dependencies.c
+++ b/src/src_dependencies/fdefine.dependencies.c
@@ -1,8 +1,14 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.fdeclare.h"
 //silver_chain_scope_end
+
+#ifdef _WIN32
+typedef __m128i __m128i_u;
+#endif
 
 #if !defined(BEARSSL_HTTPS_MOCK_UNIVERSAL_SOCKET_DEFINE)
 #include "../../dependencies/UniversalSocket.c"

--- a/src/str/fdeclare.str.h
+++ b/src/str/fdeclare.str.h
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.consts.h"
 //silver_chain_scope_end
 long private_BearsslHttps_strlen(const char *str);

--- a/src/str/fdefine.str.c
+++ b/src/str/fdefine.str.c
@@ -1,6 +1,8 @@
 
 //silver_chain_scope_start
-//mannaged by silver chain
+//DONT MODIFY THIS COMMENT
+//this import is computationally generated
+//mannaged by SilverChain: https://github.com/OUIsolutions/SilverChain
 #include "../imports/imports.fdeclare.h"
 //silver_chain_scope_end
 


### PR DESCRIPTION
we fixed that bug on darwin and,silverchain for windows, and we also fiix some problemns on widows compilation 
now:
src/one.c its full valid, and can be directly imported with:
```c
#include "src/one.c" 
``` 
now you can compile darwin directly (no downloads) with:
```bash
gcc dependencies/darwin.c -o darwin.exe
```
and you can build the lib directly in windows
```bash
darwin.exe run_blueprint
```
will make all the silverchain organization, and create al the amallgamations